### PR TITLE
Updated README file for new facilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,17 @@ Configuration files for CubeSpec TVAC testing, used by [cubespec-tvac-ts](https:
 
 ```
 data/
-  KUL/conf/                   # Site-specific setup files
+  KUL/conf/                   # Site-specific setup files (used for FSM TVAC, before splitting KUL1/KUL2)
     SETUP_KUL_00000_*.yaml    # Initial setup
     SETUP_KUL_00001_*.yaml    # Full setup (PSUs, DAQ6510, LabJack T7,...)
+    ...
+  KUL1/conf/                  # Site-specific setup files for KUL1 (used for piezo lifetime tests)
+    SETUP_KUL1_00000_*.yaml   # Initial setup
+    SETUP_KUL1_00001_*.yaml   # Full setup (wave generators, LabJack T7)
+    ...
+  KUL2/conf/                  # Site-specific setup files for KUL2 (used for STM TVAC)
+    SETUP_KUL2_00000_*.yaml   # Initial setup
+    SETUP_KUL2_00001_*.yaml   # Full setup (PSUs, MEASURpoint,...)
     ...
   common/telemetry/           # Shared telemetry dictionary
     tm-dictionary_v1.csv
@@ -21,8 +29,8 @@ Point the `CUBESPEC_CONF_DATA_LOCATION` environment variable at the site conf di
 
 ```bash
 export PROJECT=CUBESPEC
-export SITE_ID=KUL
-export CUBESPEC_CONF_DATA_LOCATION=/path/to/cubespec-tvac-conf/data/KUL/conf
+export SITE_ID=<KUL, KUL1, or KUL2>
+export CUBESPEC_CONF_DATA_LOCATION="/path/to/cubespec-tvac-conf/data/${SITE_ID}/conf"
 ```
 
 Then from Python:


### PR DESCRIPTION
Before we only had site KUL (which we used for the FSM TVAC), but now we've split this up into KUL1 (which will be used for the piezo lifetime tests) and KUL2 (which will be used for the STM TVAC).  The README file had to be updated to clarify this.